### PR TITLE
Tlbimpd changes for the MS office type libraries

### DIFF
--- a/juno/com/reflect.d
+++ b/juno/com/reflect.d
@@ -1409,7 +1409,16 @@ class Parameter {
               paramType.name_ = "GUID";
               attrs |= (ParameterAttributes.In | ParameterAttributes.Out);
             }
-            params ~= new Parameter(method, fromBstr(bstrNames[pos + 1]), paramType, pos, attrs);
+            
+            if (pos + 1 >= count)
+            {
+				//Handling for unamed parameters
+				params ~= new Parameter(method, "", paramType, pos, attrs);
+			}
+			else
+			{
+				params ~= new Parameter(method, fromBstr(bstrNames[pos + 1]), paramType, pos, attrs);
+			}
           }
         }
 


### PR DESCRIPTION
When trying to use tlbimpd on the MS office type libraries, i ran into an issue where some of the functions have parameters whose name is the same as their type. e.g,

   VARIANT_BOOL InStory (Range\* Range);

which got DMD upset.
I avoided this problem by changing tlbimpd to append 'Param' to the name of such parameters, which is the same thing that is done for parameters whose name is a D keyword.
